### PR TITLE
Utilize setTImeout instead of setInterval

### DIFF
--- a/2016/election/index.html
+++ b/2016/election/index.html
@@ -20,10 +20,11 @@
         var majorMinor = years.toFixed(5).toString();
 
         $('#time').text(majorMinor);
+        window.setTimeout(update, 50);
       };
 
       $(document).ready(function() {
-        window.setInterval(function(){ update(); }, 50);
+         update();
       });
     </script>
   </head>


### PR DESCRIPTION
update() makes DOM modifications, which can take longer than 50ms. This means you could end up with the browser locking up as lots of different tasks wait to make the DOM modification.

By chaining setTimeout within each function call, you avoid this problem and make updates 50ms from when the text got updated.