### PR TITLE
Use subpath imports for react-common

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css"
 
-import { ThemeProvider, WebVitals } from "@icco/react-common"
+import { ThemeProvider } from "@icco/react-common/ThemeProvider"
+import { WebVitals } from "@icco/react-common/WebVitals"
 import type { Metadata, Viewport } from "next"
 import { Roboto, Roboto_Mono, Roboto_Slab } from "next/font/google"
 

--- a/src/app/wiki/[...slug]/page.tsx
+++ b/src/app/wiki/[...slug]/page.tsx
@@ -1,4 +1,4 @@
-import { Social } from "@icco/react-common"
+import { Social } from "@icco/react-common/Social"
 import { isString } from "lodash"
 import { MDXComponents } from "mdx/types"
 import Link from "next/link"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,13 +4,11 @@ import {
   DocumentCheckIcon,
   PencilIcon,
 } from "@heroicons/react/24/outline"
-import {
-  RecurseLogo,
-  RecurseRing,
-  Social,
-  XXIIVVLogo,
-  XXIIVVRing,
-} from "@icco/react-common"
+import { RecurseLogo } from "@icco/react-common/RecurseLogo"
+import { RecurseRing } from "@icco/react-common/RecurseRing"
+import { Social } from "@icco/react-common/Social"
+import { XXIIVVLogo } from "@icco/react-common/XXIIVVLogo"
+import { XXIIVVRing } from "@icco/react-common/XXIIVVRing"
 import { format } from "date-fns"
 import Link from "next/link"
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
-import { Logo, ThemeToggle } from "@icco/react-common"
+import Logo from "@icco/react-common/Logo"
+import ThemeToggle from "@icco/react-common/ThemeToggle"
 import Link from "next/link"
 
 import { Breadcrumbs } from "./Breadcrumbs"

--- a/yarn.lock
+++ b/yarn.lock
@@ -657,9 +657,9 @@
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
 "@icco/react-common@*":
-  version "2026.413.1"
-  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.413.1/5d852d942ad591f6bed1b74a51391d3aa162e69c#5d852d942ad591f6bed1b74a51391d3aa162e69c"
-  integrity sha512-JWzcZQs7Dr3RZ9d7RLNl40140svQZmpRX+fyjOrbjzYj4MGpkMXnQouOzwsPsJxHxLzsqIaXpP78q4jSy2mQRA==
+  version "2026.413.2"
+  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.413.2/af81555feb8c2747d3713d1b09fb8425576f03d4#af81555feb8c2747d3713d1b09fb8425576f03d4"
+  integrity sha512-tTEUHwqhAEMzstLBKby+8plHg/tOOR+M8itMDD6bJ1yioXrzG21SJQ+GsEJx/8HV1WSPsYD1rWeU6YLvk5pySA==
   dependencies:
     vivus "^0.4.6"
 


### PR DESCRIPTION
## Summary
- Switch from barrel imports (`@icco/react-common`) to subpath imports (`@icco/react-common/Logo`, etc.)
- Avoids pulling in the entire package graph — the barrel export traces through XXIIVVRing which imports `jsdom`, causing build failures in repos that don't have jsdom installed

**Depends on:** icco/react-common#91 (subpath exports)

## Test plan
- [ ] `yarn build` succeeds
- [ ] Docker build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)