### PR TITLE
fix: extract SmallHeader into its own client component file

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,21 +1,8 @@
-"use client"
-
 import Logo from "@icco/react-common/Logo"
-import { SiteHeader } from "@icco/react-common/SiteHeader"
 import Link from "next/link"
-import { usePathname } from "next/navigation"
 
+import { SmallHeader } from "./SmallHeader"
 import { SRE } from "./SRE"
-
-export function SmallHeader() {
-  const path = usePathname()
-  const pieces = path.split("/").filter(Boolean)
-  const links = pieces.map((piece, index) => ({
-    name: piece,
-    href: `/${pieces.slice(0, index + 1).join("/")}`,
-  }))
-  return <SiteHeader links={links} />
-}
 
 export function LargeHeader() {
   const links = [

--- a/src/components/SmallHeader.tsx
+++ b/src/components/SmallHeader.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { SiteHeader } from "@icco/react-common/SiteHeader"
+import { usePathname } from "next/navigation"
+
+export function SmallHeader() {
+  const path = usePathname()
+  const pieces = path.split("/").filter(Boolean)
+  const links = pieces.map((piece, index) => ({
+    name: piece,
+    href: `/${pieces.slice(0, index + 1).join("/")}`,
+  }))
+  return <SiteHeader links={links} />
+}


### PR DESCRIPTION
## Summary

Fixes the missing header regression introduced in #298.

- Extracts `SmallHeader` into `SmallHeader.tsx` with its own `"use client"` directive
- Removes `"use client"` from `Header.tsx` so it stays a server component

**Root cause:** Putting `"use client"` on `Header.tsx` made the whole file a client component, which caused `SiteHeader` (a server component with no `"use client"`) to not SSR — resulting in no header rendered in the static HTML.

## Test plan

- [ ] Verify `<header>` / logo appears in the static HTML at `/wiki/about`
- [ ] Confirm breadcrumb links render after the theme toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)