### PR TITLE
chore(deps): bump react-common to 2026.510.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@date-fns/tz": "^1.0.2",
     "@heroicons/react": "^2.0.18",
-    "@icco/react-common": "^2026.430.1",
+    "@icco/react-common": "^2026.510.2",
     "@rowanmanning/feed-parser": "^2.0.2",
     "contentlayer2": "^0.5.0",
     "daisyui": "^5.1.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,10 +664,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@icco/react-common@^2026.430.1":
-  version "2026.430.3"
-  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.430.3/b7829a20bbfb1ba58fb83ceaee783a136c8951b9#b7829a20bbfb1ba58fb83ceaee783a136c8951b9"
-  integrity sha512-d67dBml2zRYSMNQqLQEG6gNsemitlQ4oJu2DrcRFP7XY9R/uyIGRAPvFuU2HBOr45Nq9aXZpTgMctQK8Xvhowg==
+"@icco/react-common@^2026.510.2":
+  version "2026.10510.1"
+  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.10510.1/bfa79ee2a6aef3216007a61e883a82bfe7cf30a7#bfa79ee2a6aef3216007a61e883a82bfe7cf30a7"
+  integrity sha512-I/LER85TnMCxgNhxW3imVHyNmtoNrH6ahsBBKIvyzXrCdWAVleb1mADyT9RXc0QcN6mnelvuHgs9eFESThpiZg==
   dependencies:
     "@wrksz/themes" "^0.9.0"
     vivus "^0.4.6"


### PR DESCRIPTION
## Summary

- Bumps `@icco/react-common` to `^2026.510.2`, which adds icon support and responsive nav-label collapse to `SiteHeader` (icco/react-common#106).
- No source changes: the breadcrumb-style nav links built from the pathname here don't map cleanly to a fixed icon set. This just keeps the dependency in lockstep with the rest of the icco/* sites.


